### PR TITLE
[codex] Add homepage profile metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,8 @@ locale                   : "ko-KR"
 title                    : "Ridi's TIL"
 title_separator          : "-"
 subtitle                 : # site tagline that appears below site title in masthead
-name                     : "Your"
-description              : "An amazing website."
+name                     : "Junbo Koh"
+description              : "Junbo Koh's learning notes and research-oriented TIL blog."
 url                      : "https://Ridealist.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : "Ridealist/Ridealist.github.io" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
@@ -91,9 +91,11 @@ og_image                 : # Open Graph/Twitter default site image
 # For specifying social profiles
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:
-  type                   : # Person or Organization (defaults to Person)
-  name                   : # If the user or organization name differs from the site's name
+  type                   : "Person" # Person or Organization (defaults to Person)
+  name                   : "Junbo Koh" # If the user or organization name differs from the site's name
   links: # An array of links to social media profiles
+    - "https://github.com/Ridealist/"
+    - "https://twitter.com/Junbo_Koh"
 
 # Analytics
 analytics:
@@ -113,7 +115,7 @@ author:
   links:
     - label: "Email"
       icon: "fas fa-fw fa-envelope-square"
-      # url: "gtkobo92@snu.ac.kr"
+      url: "mailto:gtkobo92@snu.ac.kr"
     - label: "Website"
       icon: "fas fa-fw fa-link"
       # url: "https://your-website.com"

--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -1,0 +1,33 @@
+# Homepage profile data for the Blog MVP redesign.
+# Keep this file as the single source for the new homepage profile panel.
+name: "Junbo Koh"
+headline: "Ongoing learner, practitioner, and researcher"
+affiliation: "Educational Technology, Seoul National University"
+location: "Seoul, South Korea"
+email: "gtkobo92@snu.ac.kr"
+
+# No profile image is committed yet. The homepage layout should render without
+# an avatar when this value is blank.
+avatar:
+avatar_alt: "Junbo Koh"
+
+bio:
+  - "I am an ongoing learner, practitioner, and researcher."
+  - "Currently Master's student, Educational Technology, Seoul National University."
+
+links:
+  - label: "Email"
+    icon: "envelope"
+    url: "mailto:gtkobo92@snu.ac.kr"
+  - label: "GitHub"
+    icon: "github"
+    url: "https://github.com/Ridealist/"
+  - label: "Twitter/X"
+    icon: "x-twitter"
+    url: "https://twitter.com/Junbo_Koh"
+
+# Optional links are intentionally omitted until real URLs are available.
+optional_links:
+  cv:
+  google_scholar:
+  linkedin:


### PR DESCRIPTION
## Summary

- Add `_data/profile.yml` as the single source of homepage profile data for the Blog MVP redesign.
- Replace placeholder site metadata in `_config.yml` with Junbo Koh's name, description, social identity, and active email link.
- Leave optional profile links and avatar empty until real assets/URLs are available.

## Validation

- `bundle exec jekyll build`

The build completes successfully. Existing Sass deprecation warnings from Minimal Mistakes are still present.

Closes #7