### PR TITLE
[codex] Clean up homepage navigation assets

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,11 +24,6 @@
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css"></noscript>
 
-<!-- Mathjax Support -->
-<script type="text/javascript" async
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
-</script>
-
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}
     <script src="{{ script | relative_url }}"></script>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -73,9 +73,9 @@
                   {% when 'linkedin' %}
                     {% assign icon_class = 'fab fa-linkedin' %}
                   {% when 'google-scholar' %}
-                    {% assign icon_class = 'ai ai-google-scholar' %}
+                    {% assign icon_class = 'fas fa-graduation-cap' %}
                   {% when 'cv' %}
-                    {% assign icon_class = 'ai ai-cv' %}
+                    {% assign icon_class = 'fas fa-file-alt' %}
                   {% else %}
                     {% assign icon_class = 'fas fa-link' %}
                   {% endcase %}

--- a/assets/logo.ico/browserconfig.xml
+++ b/assets/logo.ico/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
+            <square150x150logo src="/assets/logo.ico/mstile-150x150.png"/>
             <TileColor>#da532c</TileColor>
         </tile>
     </msapplication>

--- a/assets/logo.ico/site.webmanifest
+++ b/assets/logo.ico/site.webmanifest
@@ -1,9 +1,9 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Ridi's TIL",
+    "short_name": "Ridi's TIL",
     "icons": [
         {
-            "src": "/android-chrome-96x96.png",
+            "src": "/assets/logo.ico/android-chrome-96x96.png",
             "sizes": "96x96",
             "type": "image/png"
         }


### PR DESCRIPTION
## Summary
- Remove global MathJax loading from the shared head include so non-math pages avoid unnecessary script loading.
- Keep MathJax available through the existing `use_math: true` page path.
- Replace homepage optional Academicons mappings with Font Awesome fallbacks to avoid broken icons without adding another CDN.
- Fix favicon manifest and browserconfig icon paths to point at committed assets.

## Validation
- `bundle exec jekyll build`
- `git diff --check`
- Verified homepage has no masthead/sidebar while category and post pages keep the existing masthead/sidebar.
- Verified MathJax is absent from home/category/non-math post pages and still present on `/llm/fine-tuning-llm/`.
- Verified manifest and browserconfig icon paths resolve to committed files.

Existing Sass deprecation warnings from Minimal Mistakes are still present.

Closes #11