### PR TITLE
[codex] Structure homepage news and publications

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,0 +1,21 @@
+# Homepage news items.
+# Keep dates in ISO format for sorting; use label for display text when needed.
+items:
+  - date: 2026-06-24
+    label: "2026.06"
+    text: "Reorganizing this site into an academic profile and learning archive."
+    links: []
+
+  - date: 2024-03-18
+    label: "2024.03"
+    text: "Added notes on"
+    links:
+      - label: "problem analysis"
+        url: "/isd/problem-analysis/"
+
+  - date: 2024-02-26
+    label: "2024.02"
+    text: "Added notes on"
+    links:
+      - label: "fine-tuning LLMs"
+        url: "/llm/fine-tuning-llm/"

--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -21,15 +21,18 @@ links:
   - label: "Email"
     icon: "envelope"
     url: "mailto:gtkobo92@snu.ac.kr"
+  - label: "Google Scholar"
+    icon: "google-scholar"
+    url: "https://scholar.google.com/citations?user=2hDR1lgAAAAJ&hl=en"
+  - label: "CV"
+    icon: "cv"
+    url: "https://docs.google.com/document/d/1PGgfaXFf4T5BaNPduZi3TPmRhdUfYt5ULsStewoAdBs/edit?usp=sharing"
   - label: "GitHub"
     icon: "github"
     url: "https://github.com/Ridealist/"
-  - label: "Twitter/X"
-    icon: "x-twitter"
-    url: "https://twitter.com/Junbo_Koh"
+  - label: "LinkedIn"
+    icon: "linkedin"
+    url: "https://www.linkedin.com/in/junbokoh92/"
 
 # Optional links are intentionally omitted until real URLs are available.
 optional_links:
-  cv:
-  google_scholar:
-  linkedin:

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,0 +1,20 @@
+# Homepage publications.
+#
+# Add real publication entries as they become available. The homepage include
+# renders an empty state when these lists are empty, so build output stays
+# stable before publication metadata is finalized.
+#
+# Example entry:
+# - title: "Paper title"
+#   authors: "Junbo Koh, Coauthor A, Coauthor B"
+#   venue: "CHI 2026"
+#   venue_short: "CHI"
+#   year: 2026
+#   image: "/assets/img/publications/example.png"
+#   note: "Honorable Mention"
+#   links:
+#     - label: "PDF"
+#       url: "https://example.com/paper.pdf"
+
+selected: []
+all: []

--- a/_includes/homepage-news.html
+++ b/_includes/homepage-news.html
@@ -1,0 +1,33 @@
+{% assign news_limit = include.limit | default: 5 %}
+{% assign news_items = site.data.news.items | default: empty %}
+
+{% if news_items.size > 0 %}
+  {% assign sorted_news = news_items | sort: "date" | reverse %}
+
+  <section class="homepage-section homepage-news" aria-labelledby="news-heading">
+    <div class="homepage-section-heading">
+      <h2 id="news-heading">News</h2>
+    </div>
+
+    <ul class="homepage-news-list">
+      {% for item in sorted_news limit: news_limit %}
+        {% assign item_label = item.label | default: item.date %}
+        <li class="homepage-news-item">
+          <span class="homepage-news-date">{{ item_label }}</span>
+          <span class="homepage-news-text">
+            {{ item.text }}
+            {% if item.links %}
+              {% for link in item.links %}
+                {% assign is_external = false %}
+                {% if link.url contains "://" %}
+                  {% assign is_external = true %}
+                {% endif %}
+                <a href="{% if is_external %}{{ link.url }}{% else %}{{ link.url | relative_url }}{% endif %}"{% if is_external %} target="_blank" rel="noopener"{% endif %}>{{ link.label }}</a>{% unless forloop.last %}, {% endunless %}
+              {% endfor %}
+            {% endif %}
+          </span>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}

--- a/_includes/homepage-publication-row.html
+++ b/_includes/homepage-publication-row.html
@@ -1,0 +1,45 @@
+{% assign publication = include.publication %}
+
+<article class="homepage-publication-row{% unless publication.image or publication.venue_short %} homepage-publication-row--plain{% endunless %}">
+  {% if publication.image or publication.venue_short %}
+    <div class="homepage-publication-media">
+      {% if publication.image %}
+        <img src="{{ publication.image | relative_url }}" alt="{{ publication.title | escape }} teaser">
+      {% endif %}
+
+      {% if publication.venue_short %}
+        <span class="homepage-publication-badge">{{ publication.venue_short }}</span>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="homepage-publication-main">
+    <h3 class="homepage-publication-title">{{ publication.title }}</h3>
+
+    {% if publication.authors %}
+      <p class="homepage-publication-authors">{{ publication.authors | markdownify | remove: "<p>" | remove: "</p>" | strip }}</p>
+    {% endif %}
+
+    {% if publication.venue %}
+      <p class="homepage-publication-venue">{{ publication.venue }}</p>
+    {% endif %}
+
+    {% if publication.note %}
+      <p class="homepage-publication-note">{{ publication.note }}</p>
+    {% endif %}
+
+    {% if publication.links %}
+      <div class="homepage-publication-links">
+        {% for link in publication.links %}
+          {% if link.url %}
+            {% assign is_external = false %}
+            {% if link.url contains "://" %}
+              {% assign is_external = true %}
+            {% endif %}
+            <a href="{% if is_external %}{{ link.url }}{% else %}{{ link.url | relative_url }}{% endif %}"{% if is_external %} target="_blank" rel="noopener"{% endif %}>{{ link.label }}</a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/_includes/homepage-publications.html
+++ b/_includes/homepage-publications.html
@@ -1,0 +1,32 @@
+{% assign selected_publications = site.data.publications.selected | default: empty %}
+{% assign all_publications = site.data.publications.all | default: empty %}
+{% assign publication_count = selected_publications.size | plus: all_publications.size %}
+
+<section class="homepage-section homepage-publications" aria-labelledby="publications-heading">
+  <div class="homepage-section-heading">
+    <h2 id="publications-heading">Publications</h2>
+  </div>
+
+  {% if publication_count > 0 %}
+    {% if selected_publications.size > 0 %}
+      <div class="homepage-publication-list">
+        {% for publication in selected_publications %}
+          {% include homepage-publication-row.html publication=publication %}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    {% if all_publications.size > 0 %}
+      {% if selected_publications.size > 0 %}
+        <h3 class="homepage-publication-subheading">All Papers</h3>
+      {% endif %}
+      <div class="homepage-publication-list">
+        {% for publication in all_publications %}
+          {% include homepage-publication-row.html publication=publication %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% else %}
+    <p class="homepage-empty">Publications will be added as they become available.</p>
+  {% endif %}
+</section>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -18,6 +18,7 @@
   <head>
     {% include head.html locale=locale %}
     {% include head/custom.html %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/academicons/1.8.6/css/academicons.min.css" integrity="sha256-uFVgMKfistnJAfoCUQigIl+JfUaP47GrRKjf6CTPVmw=" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ '/assets/css/homepage.css' | relative_url }}">
   </head>
 
@@ -80,9 +81,9 @@
                   {% when 'linkedin' %}
                     {% assign icon_class = 'fab fa-linkedin' %}
                   {% when 'google-scholar' %}
-                    {% assign icon_class = 'fas fa-graduation-cap' %}
+                    {% assign icon_class = 'ai ai-google-scholar' %}
                   {% when 'cv' %}
-                    {% assign icon_class = 'fas fa-file-alt' %}
+                    {% assign icon_class = 'ai ai-cv' %}
                   {% else %}
                     {% assign icon_class = 'fas fa-link' %}
                   {% endcase %}

--- a/assets/css/homepage.scss
+++ b/assets/css/homepage.scss
@@ -170,6 +170,10 @@ body.layout--homepage {
   margin-top: 34px;
 }
 
+.homepage-content > .homepage-section:first-child {
+  margin-top: 0;
+}
+
 .homepage-section-heading {
   display: flex;
   align-items: baseline;
@@ -286,6 +290,110 @@ body.layout--homepage {
   font-size: 15px;
 }
 
+.homepage-publication-list {
+  display: grid;
+  gap: 18px;
+}
+
+.homepage-publication-subheading {
+  margin-top: 22px;
+}
+
+.homepage-publication-row {
+  display: grid;
+  grid-template-columns: 168px minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+  padding-bottom: 18px;
+  border-bottom: 1px solid #dde5ea;
+}
+
+.homepage-publication-row--plain {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.homepage-publication-media {
+  position: relative;
+  min-height: 96px;
+}
+
+.homepage-publication-media img {
+  display: block;
+  width: 100%;
+  max-height: 118px;
+  object-fit: contain;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.14);
+}
+
+.homepage-publication-badge {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 3px 8px;
+  border-radius: 2px;
+  background: #043361;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.homepage-publication-title {
+  margin: 0 0 6px;
+  color: #043361;
+  font-size: 18px;
+  line-height: 1.35;
+}
+
+.homepage-publication-authors,
+.homepage-publication-venue,
+.homepage-publication-note {
+  margin: 0 0 5px;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.homepage-publication-authors {
+  color: #30363b;
+}
+
+.homepage-publication-venue {
+  color: #4f5d67;
+  font-style: italic;
+}
+
+.homepage-publication-note {
+  color: #b65b00;
+  font-weight: 600;
+}
+
+.homepage-publication-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.homepage-publication-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 8px;
+  border: 1px solid #043361;
+  border-radius: 2px;
+  color: #043361;
+  font-size: 12px;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.homepage-publication-links a:hover {
+  border-color: #006699;
+  color: #006699;
+  text-decoration: none;
+}
+
 .homepage-footer {
   margin-top: 34px;
   padding-top: 12px;
@@ -338,12 +446,14 @@ body.layout--homepage {
 
   .homepage-post-list,
   .homepage-post-row,
+  .homepage-publication-row,
   .homepage-category-grid,
   .homepage-category-link {
     border-color: #3b4650;
   }
 
   .homepage-post-title a,
+  .homepage-publication-title,
   .homepage-category-link {
     color: #dce9ef;
   }
@@ -358,8 +468,32 @@ body.layout--homepage {
   .homepage-category-count,
   .homepage-empty,
   .homepage-news-date,
+  .homepage-publication-venue,
   .homepage-footer {
     color: #aebac3;
+  }
+
+  .homepage-publication-authors {
+    color: #dadbdf;
+  }
+
+  .homepage-publication-badge {
+    background: #3eb7f0;
+    color: #20212b;
+  }
+
+  .homepage-publication-note {
+    color: #ffbc70;
+  }
+
+  .homepage-publication-links a {
+    border-color: #64c5f2;
+    color: #64c5f2;
+  }
+
+  .homepage-publication-links a:hover {
+    border-color: #93d8f7;
+    color: #93d8f7;
   }
 }
 
@@ -418,6 +552,16 @@ body.layout--homepage {
 
   .homepage-post-row {
     display: block;
+  }
+
+  .homepage-publication-row {
+    display: block;
+  }
+
+  .homepage-publication-media {
+    max-width: 220px;
+    min-height: 0;
+    margin-bottom: 12px;
   }
 
   .homepage-post-meta {

--- a/index.html
+++ b/index.html
@@ -3,13 +3,7 @@ layout: homepage
 title: "Home"
 ---
 
-<h2>News</h2>
-
-<ul class="homepage-news-list">
-  <li><span class="homepage-news-date">2026.06</span> Reorganizing this site into an academic profile and learning archive.</li>
-  <li><span class="homepage-news-date">2024.03</span> Added notes on <a href="{{ '/isd/problem-analysis/' | relative_url }}">problem analysis</a> and instructional design foundations.</li>
-  <li><span class="homepage-news-date">2024.02</span> Added notes on <a href="{{ '/llm/fine-tuning-llm/' | relative_url }}">fine-tuning LLMs</a>.</li>
-</ul>
+{% include homepage-news.html limit=5 %}
 
 <h2>About Me</h2>
 
@@ -28,6 +22,8 @@ title: "Home"
 </ul>
 
 <p>I am interested in the intersection of learning sciences, educational technology, and human-centered AI. More specifically, I want to study how learners interact with intelligent tools, how those tools shape learning processes, and how design decisions can make AI systems more explainable, useful, and accountable in educational contexts.</p>
+
+{% include homepage-publications.html %}
 
 <h2>Writing / Notes</h2>
 


### PR DESCRIPTION
## Summary
- Move homepage News into structured _data/news.yml.
- Add structured Publications data and reusable homepage includes.
- Add homepage publication styling for light, dark, and mobile layouts.
- Update homepage profile links with LinkedIn, Google Scholar, and CV.
- Use Academicons for Google Scholar and CV icons.

## Impact
- Homepage News and Publications can now be maintained through data files instead of inline homepage markup.
- Profile links now reflect the requested public academic and contact links.
- Existing blog routes and post/category behavior are unchanged.

Closes #19
Closes #20

## Not in scope
- #21 blog/category page tone matching remains separate.

## Validation
- bundle exec jekyll build